### PR TITLE
📕 [#30] PDF 변환 및 PDF 뷰어를 위한 get_file_detail 라우트 수정

### DIFF
--- a/app/schemas/storage.py
+++ b/app/schemas/storage.py
@@ -25,3 +25,20 @@ class AudioFileDetail(BaseModel):
     uploadDate: datetime
     audioUrl: str  # S3에서 가져온 오디오 파일 URL
     contents: str  # 파일의 텍스트 내용
+
+class PDFConversionResponse(BaseModel):
+    fileID: str
+    pdfUrl: str
+    message: str = "Images successfully converted to PDF"
+
+class PDFConversionRequest(BaseModel):
+    file_ids: List[str]
+    pdf_title: str  # 사용자가 지정한 PDF 파일 이름
+
+class FileDetailResponse(BaseModel):
+    fileID: str
+    fileName: str
+    uploadDate: datetime
+    fileUrl: str  # S3에서 가져온 파일 URL
+    contents: str | None = None  # 텍스트 내용 (OCR 결과가 있는 경우)
+    fileType: str  # "audio", "pdf", "image" 등

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest==8.3.4
 httpx==0.28.1
 google-cloud-vision==3.4.4
 
-# 새롭게 추가
+# new
 uvicorn==0.34.0
 bcrypt==4.2.1
 motor==3.6.0
@@ -18,3 +18,4 @@ botocore==1.35.90
 python-multipart==0.0.20
 aiohttp==3.11.11
 google-generativeai==0.8.3
+img2pdf==0.5.1


### PR DESCRIPTION
## 📗 작업 내용
- PDF 변환 함수 구현
- image_services.py의 process_images 함수에서 위의 PDF 변환 함수를 호출
- 기존의 오디오파일만을 위한 라우트 get_file_detail을 pdf에도 대응하도록 수정
- 
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 변경 사항


### 기타 사항
