### PR TITLE
# 36 파일 상세 정보 API 개선

### DIFF
--- a/app/routes/image.py
+++ b/app/routes/image.py
@@ -47,33 +47,45 @@ async def upload_images(
             status_code=getattr(e, 'status_code', 500),
             detail=str(e)
         )
-@router.post("/receipt/ocr", response_model=Dict)
-async def process_receipt_ocr(
-        storage_name: str = Form(...),  # 보관함 이름 ("영수증")
-        title: str = Form(...),  # 사용자가 지정한 파일 제목
-        file: UploadFile = File(...),
+
+
+@router.post("/images/upload", response_model=ImageUploadResponse)
+async def upload_images(
+        storage_name: str = Form(...),
+        title: str = Form(...),
+        files: List[UploadFile] = File(...),
         user_id: str = Depends(verify_jwt),
         image_service: ImageService = Depends(get_image_service)
 ):
     """
-    영수증 이미지를 업로드하고 특화된 OCR을 수행하여 결과를 반환 및 저장
+    이미지를 업로드하고 OCR 처리 후 MP3와 PDF 파일을 생성합니다.
+
     Args:
-        storage_name: 업로드할 보관함 이름 ("영수증")
+        storage_name: 업로드할 보관함 이름 ("책", "영수증", "굿즈", "필름 사진", "서류", "티켓")
         title: 사용자가 지정한 파일 제목
-        file: 업로드할 영수증 이미지 파일
-        user_id: JWT에서 추출한 사용자 ID
-        image_service: OCR 서비스를 처리하는 ImageService 인스턴스
+        files: 업로드할 이미지 파일 목록
+        user_id: JWT에서 추출한 사용자 ID (이메일)
+
     Returns:
-        Dict: OCR 결과 및 저장된 파일 정보
+        ImageUploadResponse:
+            - file_id: 생성된 MP3 파일의 ID (primary 파일)
+            - message: 처리 결과 메시지
+
+    Notes:
+        - MP3 파일이 primary 파일로 저장되며, PDF는 연관 파일로 저장됩니다.
+        - 파일 상세 조회 시 두 파일 모두 접근 가능합니다.
     """
     try:
-        result = await image_service.process_receipt_ocr(
+        result = await image_service.process_images(
             storage_name=storage_name,
             title=title,
-            file=file,
+            files=files,
             user_id=user_id
         )
-        return result
+        return ImageUploadResponse(
+            file_id=result.file_id,
+            message="Files processed and stored successfully. Access both MP3 and PDF through file details."
+        )
     except Exception as e:
         raise HTTPException(
             status_code=getattr(e, 'status_code', 500),

--- a/app/routes/image.py
+++ b/app/routes/image.py
@@ -15,42 +15,6 @@ async def get_image_service(db: AsyncIOMotorClient = Depends(get_database)):
 
 @router.post("/images/upload", response_model=ImageUploadResponse)
 async def upload_images(
-    storage_name: str = Form(...),  # 보관함 이름 ("책", "영수증" 등)
-    title: str = Form(...),         # 사용자가 지정한 파일 제목
-    files: List[UploadFile] = File(...),
-    user_id: str = Depends(verify_jwt),
-    image_service: ImageService = Depends(get_image_service)
-):
-    """
-    이미지를 업로드하고 OCR을 수행하여 결과를 반환
-
-    Args:
-        storage_name: 업로드할 보관함 이름 ("책", "영수증", "굿즈", "필름 사진", "서류", "티켓")
-        title: 사용자가 지정한 파일 제목
-        files: 업로드할 이미지 파일 목록
-        user_id: JWT에서 추출한 사용자 ID (이메일)
-    """
-    try:
-        result = await image_service.process_images(
-            storage_name=storage_name,
-            title=title,
-            files=files,
-            user_id=user_id
-        )
-        return ImageUploadResponse(
-            file_id=result.file_id,
-            message="Images processed and uploaded successfully."
-        )
-    except Exception as e:
-        # 에러 메시지를 그대로 클라이언트에 전달
-        raise HTTPException(
-            status_code=getattr(e, 'status_code', 500),
-            detail=str(e)
-        )
-
-
-@router.post("/images/upload", response_model=ImageUploadResponse)
-async def upload_images(
         storage_name: str = Form(...),
         title: str = Form(...),
         files: List[UploadFile] = File(...),
@@ -86,6 +50,39 @@ async def upload_images(
             file_id=result.file_id,
             message="Files processed and stored successfully. Access both MP3 and PDF through file details."
         )
+    except Exception as e:
+        raise HTTPException(
+            status_code=getattr(e, 'status_code', 500),
+            detail=str(e)
+        )
+
+@router.post("/receipt/ocr", response_model=Dict)
+async def process_receipt_ocr(
+        storage_name: str = Form(...),  # 보관함 이름 ("영수증")
+        title: str = Form(...),  # 사용자가 지정한 파일 제목
+        file: UploadFile = File(...),
+        user_id: str = Depends(verify_jwt),
+        image_service: ImageService = Depends(get_image_service)
+):
+    """
+    영수증 이미지를 업로드하고 특화된 OCR을 수행하여 결과를 반환 및 저장
+    Args:
+        storage_name: 업로드할 보관함 이름 ("영수증")
+        title: 사용자가 지정한 파일 제목
+        file: 업로드할 영수증 이미지 파일
+        user_id: JWT에서 추출한 사용자 ID
+        image_service: OCR 서비스를 처리하는 ImageService 인스턴스
+    Returns:
+        Dict: OCR 결과 및 저장된 파일 정보
+    """
+    try:
+        result = await image_service.process_receipt_ocr(
+            storage_name=storage_name,
+            title=title,
+            file=file,
+            user_id=user_id
+        )
+        return result
     except Exception as e:
         raise HTTPException(
             status_code=getattr(e, 'status_code', 500),

--- a/app/schemas/storage.py
+++ b/app/schemas/storage.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 class StorageInfo(BaseModel):
     storageName: str # 보관함 이름 (예: "책 보관함", "편지 보관함" 등)
@@ -35,6 +35,10 @@ class PDFConversionRequest(BaseModel):
     file_ids: List[str]
     pdf_title: str  # 사용자가 지정한 PDF 파일 이름
 
+class RelatedFileInfo(BaseModel):
+    fileUrl: str
+    fileType: str
+
 class FileDetailResponse(BaseModel):
     fileID: str
     fileName: str
@@ -42,3 +46,4 @@ class FileDetailResponse(BaseModel):
     fileUrl: str  # S3에서 가져온 파일 URL
     contents: str | None = None  # 텍스트 내용 (OCR 결과가 있는 경우)
     fileType: str  # "audio", "pdf", "image" 등
+    relatedFile: Optional[RelatedFileInfo]

--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ app.add_middleware(
         "http://localhost:3000",
         "https://6c68-118-34-210-44.ngrok-free.app",
         "http://ec2-54-180-149-98.ap-northeast-2.compute.amazonaws.com",
-        "https://nongmo-a2d.com"
+        "https://nongmo-a2d.com",
+        "*"
     ],
     allow_credentials=True,
     allow_methods=["*"],  # 모든 HTTP 메서드 허용 (POST, GET, OPTIONS 등)


### PR DESCRIPTION
## 📗 작업 내용
- 파일 상세 정보 API (get_file_detail) 함수를 개선하여 primary 파일과 연관된 파일 정보를 효율적으로 조회하고, 파일 타입을 정확하게 결정하도록 수정했습니다.
- is_primary 필드를 활용하여 primary 파일과 연관 파일을 명확하게 구분하고 조회하도록 했습니다.
- related_file의 파일 타입을 mime_type을 기반으로 결정하도록 변경했습니다.
- related_file 조회 시 발생할 수 있는 에러에 대한 처리를 추가했습니다.
- 코드 가독성을 높이기 위해 주석을 추가하고 변수명을 개선했습니다


### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### ✅ 변경 사항
- get_file_detail 함수의 로직을 개선하여 primary 파일과 연관 파일 정보를 효율적으로 조회합니다.
- is_primary 필드를 활용하여 primary 파일과 연관 파일을 명확하게 구분합니다.
- related_file의 파일 타입을 mime_type을 기반으로 결정합니다.
- related_file 조회 시 발생할 수 있는 에러에 대한 처리를 추가했습니다.
- 주석을 추가하고 변수명을 개선하여 코드 가독성을 높였습니다.

### ✅ 참고 사항
- 기존 API 호출과의 호환성을 유지하면서 개선되었습니다.


### 🔥  회고
- 
