### PR TITLE
📕 #42 영수증 OCR API를 여러 장의 영수증을 처리할 수 있도록 개선

### DIFF
--- a/app/routes/image.py
+++ b/app/routes/image.py
@@ -29,7 +29,7 @@ async def upload_images(
         title: 사용자가 지정한 파일 제목
         files: 업로드할 이미지 파일 목록
         user_id: JWT에서 추출한 사용자 ID (이메일)
-
+        image_service: ImageService 인스턴스 - OCR 서비스 처리 담당
     Returns:
         ImageUploadResponse:
             - file_id: 생성된 MP3 파일의 ID (primary 파일)
@@ -58,28 +58,29 @@ async def upload_images(
 
 @router.post("/receipt/ocr", response_model=Dict)
 async def process_receipt_ocr(
-        storage_name: str = Form(...),  # 보관함 이름 ("영수증")
-        title: str = Form(...),  # 사용자가 지정한 파일 제목
-        file: UploadFile = File(...),
-        user_id: str = Depends(verify_jwt),
-        image_service: ImageService = Depends(get_image_service)
+    storage_name: str = Form(...),
+    title: str = Form(...),
+    files: List[UploadFile] = File(...),  # 파일 목록으로 변경
+    user_id: str = Depends(verify_jwt),
+    image_service: ImageService = Depends(get_image_service)
 ):
     """
-    영수증 이미지를 업로드하고 특화된 OCR을 수행하여 결과를 반환 및 저장
-    Args:
-        storage_name: 업로드할 보관함 이름 ("영수증")
-        title: 사용자가 지정한 파일 제목
-        file: 업로드할 영수증 이미지 파일
-        user_id: JWT에서 추출한 사용자 ID
-        image_service: OCR 서비스를 처리하는 ImageService 인스턴스
-    Returns:
-        Dict: OCR 결과 및 저장된 파일 정보
-    """
+   다중 영수증 이미지 OCR 처리
+
+   Args:
+       storage_name: 보관함 이름 ("영수증")
+       title: 파일 제목
+       files: 영수증 이미지 파일 목록
+       user_id: 사용자 ID
+       image_service: ImageService 인스턴스 - OCR 서비스 처리 담당
+   Returns:
+       Dict: OCR 결과 및 파일 정보
+   """
     try:
         result = await image_service.process_receipt_ocr(
             storage_name=storage_name,
             title=title,
-            file=file,
+            files=files,
             user_id=user_id
         )
         return result


### PR DESCRIPTION
## 📗 작업 내용
- 영수증 OCR API를 여러 장의 영수증을 처리할 수 있도록 개선

### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### ✅ 변경 사항
1. 다중 영수증 처리 기능 추가

- 여러 영수증을 하나의 그룹으로 처리
- 각 영수증별 OCR 결과를 combined_contents에 저장
- 모든 영수증 이미지의 S3 저장 경로 추적


2. 저장 구조 개선

- 단일 그룹 ID로 연관된 파일들 관리
- 대표 이미지(s3_key)와 추가 이미지(additional_s3_keys) 구분
- storage_count는 그룹 단위로 1 증가

### ✅ 참고 사항
- group_id를 통한 파일 관리로 연관 파일 추적 용이
- combined_contents로 모든 영수증 OCR 결과 통합 관리

### 🔥  회고
여러 장을 생각하고 있지 못했는 데 기능 하나 만들고 QA 해보는 거 아주 좋다. 
