### PR TITLE
📕 [# 43] vertices 받아서 이미지 처리할 수 있도록 수정

### DIFF
--- a/app/routes/image.py
+++ b/app/routes/image.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, UploadFile, Depends, Form, File, HTTPException
 from app.schemas.image import ImageUploadResponse
 from app.services.image_services import ImageService
-from typing import List
+from typing import List, Optional
 from app.services.image_services import verify_jwt
 from motor.motor_asyncio import AsyncIOMotorClient
 from app.core.database import get_database
 from typing import Dict
+import json
 
 router = APIRouter()
 
@@ -18,16 +19,18 @@ async def upload_images(
         storage_name: str = Form(...),
         title: str = Form(...),
         files: List[UploadFile] = File(...),
+        pages_vertices_data: Optional[str] = Form(None),  # 선택적 정점 데이터
         user_id: str = Depends(verify_jwt),
         image_service: ImageService = Depends(get_image_service)
 ):
     """
-    이미지를 업로드하고 OCR 처리 후 MP3와 PDF 파일을 생성합니다.
+    이미지를 업로드하고 필요한 경우 정점 정보를 기반으로 이미지를 변환한 후 OCR 처리합니다.
 
     Args:
         storage_name: 업로드할 보관함 이름 ("책", "영수증", "굿즈", "필름 사진", "서류", "티켓")
         title: 사용자가 지정한 파일 제목
         files: 업로드할 이미지 파일 목록
+        pages_vertices_data: 이미지 변환을 위한 정점 정보 (선택적)
         user_id: JWT에서 추출한 사용자 ID (이메일)
 
     Returns:
@@ -40,11 +43,23 @@ async def upload_images(
         - 파일 상세 조회 시 두 파일 모두 접근 가능합니다.
     """
     try:
+        # pages_vertices_data가 문자열로 전달되므로 JSON으로 파싱
+        vertices_data = None
+        if pages_vertices_data:
+            try:
+                vertices_data = json.loads(pages_vertices_data)
+            except json.JSONDecodeError:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Invalid vertices data format"
+                )
+
         result = await image_service.process_images(
             storage_name=storage_name,
             title=title,
             files=files,
-            user_id=user_id
+            user_id=user_id,
+            vertices_data=vertices_data
         )
         return ImageUploadResponse(
             file_id=result.file_id,

--- a/app/schemas/image.py
+++ b/app/schemas/image.py
@@ -1,4 +1,12 @@
 from pydantic import BaseModel
+from typing import List, Dict, Optional
+
+class Point(BaseModel):
+    x: float
+    y: float
+
+class PageVertices(BaseModel):
+    points: List[Point]
 
 class ImageUploadRequest(BaseModel):
     title: str

--- a/app/services/image_services.py
+++ b/app/services/image_services.py
@@ -1,7 +1,7 @@
 import os
 import urllib
 import uuid
-from typing import List
+from typing import List, Optional, Tuple
 from fastapi import UploadFile, HTTPException, status, Depends, Header
 from app.models.image import ImageMetadata, ImageDocument
 from app.core.config import (
@@ -28,6 +28,8 @@ import ssl
 import logging
 import asyncio
 from app.services.storage_service import StorageService
+import cv2
+import numpy as np
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -113,10 +115,66 @@ class ImageService:
         result = await self.files_collection.insert_one(file_doc)
         return str(result.inserted_id)
 
-    async def process_images(self, storage_name: str, title: str, files: List[UploadFile],
-                             user_id: str = Depends(verify_jwt)):
+    async def transform_image(self, image_bytes: bytes, vertices: List[dict]) -> bytes:
         """
-        여러 이미지를 하나의 통합된 파일로 처리하는 메서드
+        이미지를 정점 정보를 기반으로 변환합니다.
+        
+        Args:
+            image_bytes: 원본 이미지 바이트
+            vertices: 변환할 정점 정보 리스트 [{"x": float, "y": float}, ...]
+        
+        Returns:
+            bytes: 변환된 이미지 바이트
+        """
+        # 이미지 바이트를 numpy 배열로 변환
+        nparr = np.frombuffer(image_bytes, np.uint8)
+        img = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+        
+        if img is None:
+            raise HTTPException(status_code=400, detail="Invalid image data")
+
+        # 원본 이미지의 정점 좌표
+        src_points = np.float32([[v["x"], v["y"]] for v in vertices])
+        
+        # 변환된 이미지의 크기 계산
+        width = max(
+            np.linalg.norm(src_points[1] - src_points[0]),
+            np.linalg.norm(src_points[2] - src_points[3])
+        )
+        height = max(
+            np.linalg.norm(src_points[3] - src_points[0]),
+            np.linalg.norm(src_points[2] - src_points[1])
+        )
+        
+        # 대상 정점 좌표 설정
+        dst_points = np.float32([
+            [0, 0],
+            [width - 1, 0],
+            [width - 1, height - 1],
+            [0, height - 1]
+        ])
+        
+        # 투시 변환 행렬 계산 및 적용
+        matrix = cv2.getPerspectiveTransform(src_points, dst_points)
+        transformed = cv2.warpPerspective(img, matrix, (int(width), int(height)))
+        
+        # 변환된 이미지를 바이트로 인코딩
+        success, transformed_bytes = cv2.imencode('.jpg', transformed)
+        if not success:
+            raise HTTPException(status_code=500, detail="Failed to encode transformed image")
+            
+        return transformed_bytes.tobytes()
+
+    async def process_images(
+        self,
+        storage_name: str,
+        title: str,
+        files: List[UploadFile],
+        user_id: str,
+        vertices_data: Optional[List[List[dict]]] = None
+    ):
+        """
+        이미지들을 처리하고 필요한 경우 변환합니다.
         """
         if storage_name not in self.ALLOWED_STORAGE_NAMES:
             raise HTTPException(
@@ -145,22 +203,27 @@ class ImageService:
             )
 
             total_size = 0
-            for file in files:
-                file_path = os.path.join(upload_dir, file.filename)
+            for idx, file in enumerate(files):
                 try:
                     content = await file.read()
                     if not content:
                         raise HTTPException(status_code=400, detail=f"Empty file: {file.filename}")
 
-                    total_size += len(content)
+                    # 정점 정보가 있는 경우 이미지 변환
+                    if vertices_data and len(vertices_data) > idx:
+                        content = await self.transform_image(content, vertices_data[idx])
+
+                    # 임시 파일 저장
+                    file_path = os.path.join(upload_dir, file.filename)
                     with open(file_path, "wb") as f:
                         f.write(content)
-
+                    
                     image_paths.append(file_path)
+                    total_size += len(content)
 
-                    # OCR 텍스트 추출
+                    # OCR 처리
                     text = await self._call_clova_ocr(file)
-                    combined_text.extend(text)  # 모든 텍스트를 하나의 리스트에 추가
+                    combined_text.extend(text)
 
                 except (IOError, ValueError) as e:
                     raise HTTPException(status_code=400, detail=f"Failed to process file: {e}")

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:3000",
-        "https://6c68-118-34-210-44.ngrok-free.app",
+        "https://e336-175-195-226-193.ngrok-free.app",
         "http://ec2-54-180-149-98.ap-northeast-2.compute.amazonaws.com",
         "https://nongmo-a2d.com",
         "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ python-multipart==0.0.20
 aiohttp==3.11.11
 google-generativeai==0.8.3
 img2pdf==0.5.1
+opencv-python==4.10.0.84
+numpy==2.2.1


### PR DESCRIPTION
## 📗 작업 내용
- vertices를 받아서 이미지를 처리할 수 있도록 수정

### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### ✅ 변경 사항
- image 라우터에 있던 스키마코드를 스키마 폴더의 image.py로 이동
- 라우터에서 vertices에 NULL이 들어와도 처리할 수 있도록 수정

### ✅ 참고 사항
-

### 📸 작업 미리보기
- 

### 🔥  회고
- 
