### PR TITLE
📕 [# 54] 영수증 크롭을 위한 기능 추가

### DIFF
--- a/app/routes/image.py
+++ b/app/routes/image.py
@@ -128,6 +128,7 @@ async def process_receipt_ocr(
         storage_name: str = Form(...),
         title: str = Form(...),
         files: List[UploadFile] = File(...),  # 파일 목록으로 변경
+        pages_vertices_data: Optional[str] = Form(None),  # 문자열로 받음
         user_id: str = Depends(verify_jwt),
         image_service: ImageService = Depends(get_image_service)
 ):
@@ -138,17 +139,71 @@ async def process_receipt_ocr(
        storage_name: 보관함 이름 ("영수증")
        title: 파일 제목
        files: 영수증 이미지 파일 목록
+       pages_vertices_data: 이미지별 4점 좌표 리스트 또는 null (선택적)
+            예시: [
+                [{x: 85.5, y: 307.8}, {x: 231.6, y: 306.8}, {x: 240.1, y: 572.4}, {x: 87.6, y: 574.5}],
+                null
+            ]
        user_id: 사용자 ID
        image_service: ImageService 인스턴스 - OCR 서비스 처리 담당
    Returns:
        Dict: OCR 결과 및 파일 정보
    """
     try:
+        logger.info(f"Received pages_vertices_data: {pages_vertices_data}")
+        # 문자열로 받은 정점 데이터를 파싱
+        vertices_data = None
+        if pages_vertices_data:
+            try:
+                parsed_data = json.loads(pages_vertices_data)
+                logger.info(f"Parsed vertices data: {parsed_data}")
+                # 데이터 검증
+                if not isinstance(parsed_data, list):
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Vertices data must be a list"
+                    )
+                
+                # null이 아닌 vertices만 포함하는 리스트 생성
+                vertices_data = []
+                for idx, vertices in enumerate(parsed_data):
+                    logger.debug(f"Processing vertices set {idx}: {vertices}")
+                    if vertices is not None:  # null이 아닌 경우에만 검증
+                        if not isinstance(vertices, list) or len(vertices) != 4:
+                            logger.error(f"Invalid vertices format at index {idx}: {vertices}")
+                            raise HTTPException(
+                                status_code=400,
+                                detail="Each vertices set must have exactly 4 points"
+                            )
+                        for point_idx, point in enumerate(vertices):
+                            logger.debug(f"Checking point {point_idx} in set {idx}: {point}")
+                            if not isinstance(point, dict) or not all(k in point for k in ('x', 'y')):
+                                logger.error(f"Invalid point format at index {idx}, point {point_idx}: {point}")
+                                raise HTTPException(
+                                    status_code=400,
+                                    detail="Each point must have 'x' and 'y' coordinates"
+                                )
+                        vertices_data.append(vertices)
+                        logger.info(f"Added vertices set {idx}: {vertices}")
+                    else:
+                        vertices_data.append(None)
+                        logger.info(f"Added None for vertices set {idx}")
+
+            except json.JSONDecodeError as e:
+                logger.error(f"JSON decode error: {str(e)}, received data: {pages_vertices_data}")
+                raise HTTPException(
+                    status_code=400,
+                    detail="Invalid JSON format for vertices data"
+                )
+
+        logger.info(f"Final vertices_data being sent to process_images: {vertices_data}")
+
         result = await image_service.process_receipt_ocr(
             storage_name=storage_name,
             title=title,
             files=files,
-            user_id=user_id
+            user_id=user_id,
+            vertices_data=vertices_data
         )
         return result
     except Exception as e:


### PR DESCRIPTION
## 📗 작업 내용
- 영수증 크롭을 위한 라우터, 서비스 함수 추가
- 기존의 이미지를 pdf로 변환해주는 함수를 영수증에도 대응 할 수 있도록 변경


### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### ✅ 변경 사항
- routes/image.py에 "/receipt/ocr" 라우터 추가
- storage_service.py의 create_pdf_from_images함수 storage_type을 받을 수 있도록 변경
- image_services.py의 process_receipt_ocr함수가 이미지 크롭을 적용할 수 있도록 변경(process_images함수와 통합 여지 있음)

### ✅ 참고 사항
-

### 📸 작업 미리보기
- 

### 🔥  회고
- 
