### PR TITLE
📕 #71 파일 최근 열람한 시간 관련 API 구현

### DIFF
--- a/app/routes/storage.py
+++ b/app/routes/storage.py
@@ -47,8 +47,10 @@ async def get_storage_detail(
             "ticket": "티켓"
         }
         
+        # 한글로 변경
         korean_storage_name = storage_name_mapping.get(storage_name, storage_name)
         
+        # DB에서 상세 정보 조회
         storage_service = await StorageService.create(db)
         return await storage_service.get_storage_detail(user_email, korean_storage_name)
     except HTTPException as e:
@@ -77,6 +79,27 @@ async def get_file_detail(
         raise HTTPException(
             status_code=500,
             detail=f"Failed to fetch file detail: {str(e)}"
+        )
+        
+@router.post("/files/{file_id}/recent")
+async def update_recent_date(
+    file_id: str,
+    user_email: str = Depends(verify_jwt),
+    db: AsyncIOMotorDatabase = Depends(get_database)
+):
+    """
+    특정 파일의 최근 열람일을 갱신합니다.
+    """
+    try:
+        storage_service = await StorageService.create(db)
+        await storage_service.update_recent_date(user_email, file_id)
+        return {"message": "Recent date updated successfully"}
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to update recent date: {str(e)}"
         )
 
 @router.delete("/files/{file_id}")

--- a/app/schemas/storage.py
+++ b/app/schemas/storage.py
@@ -14,7 +14,8 @@ class FileDetail(BaseModel):
     fileID: str # 파일 ID
     fileName: str # 파일 이름
     uploadDate: datetime # 업로드 날짜
-
+    recentDate: datetime # 최근 수정 날짜
+    
 class StorageDetailResponse(BaseModel):
     storageName: str # 보관함 이름
     fileList: List[FileDetail] # FileDetail 객체들의 리스트

--- a/app/services/image_services.py
+++ b/app/services/image_services.py
@@ -65,6 +65,7 @@ class ImageService:
             "file_size": file_info["file_size"],
             "mime_type": file_info["mime_type"],
             "created_at": now,
+            "recented_at": now,
             "updated_at": now,
             "is_primary": file_info.get("is_primary", False)
         }

--- a/app/services/storage_service.py
+++ b/app/services/storage_service.py
@@ -85,7 +85,8 @@ class StorageService:
                 file_list.append(FileDetail(
                     fileID=str(file["_id"]),
                     fileName=file["title"],
-                    uploadDate=file["created_at"]
+                    uploadDate=file["created_at"],
+                    recentDate=file["recented_at"]
                 ))
 
             return StorageDetailResponse(


### PR DESCRIPTION
## 📗 작업 내용
- `image_services` 파일에서 파일 생성 시, `recented_at` 컬럼 생성
- 보관함 데이터를 불러오는 API에 `RecentDate`를 추가
- 열람 시간을 저장하는 API 구현


### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 🔥  회고
- 짱.
