### PR TITLE
 📕 [# 80] 파일 삭제시 보관함 카운트 이슈 해결

### DIFF
--- a/app/services/storage_service.py
+++ b/app/services/storage_service.py
@@ -189,6 +189,15 @@ class StorageService:
                     status_code=403,
                     detail="You do not have permission to delete this file"
                 )
+            
+            # 보관함의 file_count 감소
+            storage = await self.db.storages.find_one({"_id": file["storage_id"]})
+            if storage:
+                await self.db.storages.update_one(
+                    {"_id": storage["_id"]},
+                    {"$inc": {"file_count": -1}}
+                )
+
 
             self.s3_client.delete_object(
                 Bucket=S3_BUCKET_NAME,


### PR DESCRIPTION
## 📗 작업 내용
- 파일 삭제하면 보관함 DB에서 file_count가 수정되도록 변경


### ✅ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### ✅ 변경 사항
- storage_service.py 보관함에서 file_count  개수 수정되도록 변경

### ✅ 참고 사항
-

### 📸 작업 미리보기
- 

### 🔥  회고
- 
